### PR TITLE
fix for size data is missing from output report #4

### DIFF
--- a/output_processor/json_metadata.py
+++ b/output_processor/json_metadata.py
@@ -69,9 +69,8 @@ class JsonMetadata():
                     }
 
                 # only add volume for requests, nonsensical for investigations
-                # TODO: put back the following two lines if DataCite begins accepting volume
-                # if meth.endswith('_requests'):
-                #     s['volume'] = FacetedStat.sum(stat, 'vol')
+                if meth.endswith('_requests'):
+                    s['volume'] = FacetedStat.sum(stat, 'vol')
                 s['country-counts'] = country_counts
 
                 # only add volume for requests, nonsensical for investigations


### PR DESCRIPTION
@sfisher hi! It was a pleasure speaking with you the other week. Thanks for opening #4 about size/volume being missing from the JSON report. As we discussed, even if DataCite doesn't accept the size yet, for Dataverse we plan to process the JSON files created by Counter Processor and save the metrics in our database (diagram below) so we're interested in support for size. The fix is simply uncommenting some code you already wrote. Thank you!

![mdc-arch](https://user-images.githubusercontent.com/21006/51997720-45189500-2485-11e9-8e41-9c54b0d5601f.png)

The issue we're using on our side is https://github.com/IQSS/dataverse/issues/4821