### PR TITLE
Update PyYAML version so GitHub doesn't complain about security issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ peewee==3.0.12
 requests==2.18.4
 geoip2==2.9.0
 python_dateutil==2.7.3
-PyYAML==3.13
+PyYAML==4.2b2


### PR DESCRIPTION
Even though the security issues are unlikely to be a problem given our usage pattern, it seems reasonable to do this update. And it doesn't break anything.