### PR TITLE
Document new status codes

### DIFF
--- a/upload/upload.py
+++ b/upload/upload.py
@@ -49,6 +49,20 @@ def send_to_datacite():
         data = myfile.read()
 
     # post or put the information
+    #
+    # Note: the submitting report API has been expanded to return more status codes, according to https://github.com/datacite/sashimi/pull/129
+    # The new set of codes are:
+    # 200	Report has been updated
+    # 201	Report has been CREATED and validated correctly
+    # 202	Report has been ACCEPTED and its waiting for validation
+    # 404	Report does not exist
+    # 422	Report or sub-report has failed validation
+
+    # The validation here is still OK (200-299 is considered OK), retry on 500 errors, others codes log errors for examination.
+    # The new 200-level codes will mostly be useful for monitoring DataCite status or re-checking previous submissions which
+    # this class doesn't really do and would likely happen in a separate monitoring process since the other 200 codes happen
+    # asynchronously to be checked after submission time.
+
     my_id = config.Config().current_id()
     if my_id is None:
         my_url = urljoin(config.Config().hub_base_url, 'reports')


### PR DESCRIPTION
This documents status code changes for checking status of a submission after the fact.

These might be useful to a monitoring process or something that validates a long while post-submission, but since the processor is focused on processing and submission, doesn't really involve code changes unless we add methods to recheck report status and other things.

We have a separate utility to do that in ruby and it checks status by looking up pages of query results compared to our json report sizes.  If there are no results or if the number of pages of results is suspiciously too low compared to our report size then we consider the report failed and in need of re-submission in that utility (and submit it again).  That utility runs once a month.